### PR TITLE
persp-selected-face should not inherit mode-line

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -1266,7 +1266,7 @@ Also bind `class' to ((class color) (min-colors 89))."
 ;;;;; paren-face
    `(parenthesis ((t (:foreground ,zenburn-fg-1))))
 ;;;;; perspective
-   `(persp-selected-face ((t (:foreground ,zenburn-yellow-2 :inherit mode-line))))
+   `(persp-selected-face ((t (:foreground ,zenburn-yellow-2))))
 ;;;;; powerline
    `(powerline-active1 ((t (:background ,zenburn-bg-05 :inherit mode-line))))
    `(powerline-active2 ((t (:background ,zenburn-bg+2 :inherit mode-line))))


### PR DESCRIPTION
When `persp-selected-face` inherits mode-line like this, the wrong face is used for inactive modelines.

This issue was first reported as https://github.com/gonewest818/dimmer.el/issues/39, however in debugging it was shown the issue is the definition of the face and not, per se, an issue with `dimmer` or `perspective`.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
